### PR TITLE
[Fix] - Add node-gyp dependencies to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ FROM node:14-alpine@sha256:7bcf853eeb97a25465cb385b015606c22e926f548cbd117f85b71
 ENV NODE_ENV=production
 
 WORKDIR /app
+RUN apk add --update --no-cache g++ make python3 && ln -sf python3 /usr/bin/python
 
 COPY ["package.json", "package-lock.json*", "./"]
 RUN npm ci --only=production


### PR DESCRIPTION
This PR adds missing dependencies to the Dockerfile. Some dependencies on the sentinel currently require `node-gyp` and as per they README, `node-gyp` also depends on the following [1](https://github.com/nodejs/node-gyp#on-unix):

> ## On Unix
> Python v3.7, v3.8, v3.9, or v3.10
> make
> A proper C/C++ compiler toolchain, like [GCC](https://gcc.gnu.org/)

This PR makes `docker-compose build` to run without issues