### PR TITLE
add exclusion tokens option

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -64,6 +64,10 @@ HTTP_RPC_NODE=
 ## Format: 0x000…,0x000…,0x000…,...
 #TOKENS=
 
+## List of Super Tokens not to be supervised.
+## Has an effect only if TOKENS is not set and thus defaults to all tokens.
+#EXCLUDED_TOKENS=
+
 
 ## --- LIQUIDATION PARAMETERS ---
 

--- a/src/config/configuration.js
+++ b/src/config/configuration.js
@@ -17,6 +17,9 @@ class Config {
       if (config.tokens !== undefined && config.tokens !== "") {
         this.TOKENS = config.tokens.split(",");
       }
+      if (config.excluded_tokens !== undefined && config.excluded_tokens !== "") {
+        this.EXCLUDED_TOKENS = config.excluded_tokens.split(",");
+      }
       this.DB = (config.db_path !== undefined && config.db_path !== "") ? config.db_path : "./db.sqlite";
       this.ADDITIONAL_LIQUIDATION_DELAY = config.additional_liquidation_delay || 0;
       this.TX_TIMEOUT = config.tx_timeout * 1000 || 60000;
@@ -48,10 +51,13 @@ class Config {
       this.MNEMONIC_INDEX = process.env.MNEMONIC_INDEX || 0;
       this.PRIVATE_KEY = process.env.PRIVATE_KEY;
       this.MAX_QUERY_BLOCK_RANGE = process.env.MAX_QUERY_BLOCK_RANGE || 2000;
+      this.TOKENS = undefined;
       if (process.env.TOKENS !== undefined && process.env.TOKENS !== "") {
         this.TOKENS = process.env.TOKENS.split(",");
-      } else {
-        this.TOKENS = undefined;
+      }
+      this.EXCLUDED_TOKENS = undefined;
+      if (process.env.EXCLUDED_TOKENS !== undefined && process.env.EXCLUDED_TOKENS !== "") {
+          this.EXCLUDED_TOKENS = process.env.EXCLUDED_TOKENS.split(",");
       }
       this.DB = (process.env.DB_PATH !== undefined && process.env.DB_PATH !== "") ? process.env.DB_PATH : "./db.sqlite";
       this.ADDITIONAL_LIQUIDATION_DELAY = process.env.ADDITIONAL_LIQUIDATION_DELAY || 0;
@@ -81,20 +87,27 @@ class Config {
       this.MAX_TX_NUMBER = process.env.MAX_TX_NUMBER || 100;
     }
 
-    // token filter also affects ONLY_LISTED_TOKENS
+    // token filter affects ONLY_LISTED_TOKENS and EXCLUDED_TOKENS
     if (this.TOKENS !== undefined) {
       this.ONLY_LISTED_TOKENS = false;
+      this.EXCLUDED_TOKENS = undefined;
     }
 
+    if (this.TOKENS !== undefined &&
+        Array.from(new Set(this.TOKENS.map(x => x.toLowerCase()))).length !== this.TOKENS.length
+    ) {
+      throw Error("Config.constructor(): duplicate tokens set from configuration: TOKENS");
+    }
+
+    if (this.EXCLUDED_TOKENS !== undefined &&
+        Array.from(new Set(this.EXCLUDED_TOKENS.map(x => x.toLowerCase()))).length !== this.EXCLUDED_TOKENS.length
+    ) {
+        throw Error("Config.constructor(): duplicate tokens set from configuration: EXCLUDED_TOKENS");
+    }
     if (this.HTTP_RPC_NODE === undefined) {
       throw Error("Config.constructor(): required configuration item missing: HTTP_RPC_NODE");
     }
 
-    if (this.TOKENS !== undefined &&
-      Array.from(new Set(this.TOKENS.map(x => x.toLowerCase()))).length !== this.TOKENS.length
-    ) {
-      throw Error("Config.constructor(): duplicate tokens set from configuration: TOKENS");
-    }
   }
 
   loadNetworkInfo (chainId) {
@@ -114,6 +127,7 @@ class Config {
       OBSERVER: this.OBSERVER,
       MAX_QUERY_BLOCK_RANGE: this.MAX_QUERY_BLOCK_RANGE,
       TOKENS: this.TOKENS,
+      EXCLUDED_TOKENS: this.EXCLUDED_TOKENS,
       DB_PATH: this.DB,
       ADDITIONAL_LIQUIDATION_DELAY: this.ADDITIONAL_LIQUIDATION_DELAY,
       TX_TIMEOUT: this.TX_TIMEOUT,

--- a/src/config/loadCmdArgs.js
+++ b/src/config/loadCmdArgs.js
@@ -16,6 +16,7 @@ program
     .option("-m, --mnemonic [value]", "Mnemonic")
     .option("--max-query-block-range [value]", "Max query block range (default: 2000)")
     .option("-t, --tokens [value]", "Addresses of SuperTokens the sentinel should watch (default: all SuperTokens)")
+    .option("-e, --exclude-tokens [value]", "Addresses of SuperTokens the sentinel should excluded (default: none)")
     .option("-p, --db-path [value]", "Path of the DB file (default: db.sqlite)")
     .option("-d, --additional-liquidation-delay [value]", "Time to wait (seconds) after an agreement becoming critical before doing a liquidation (default: 0)")
     .option("--tx-timeout [value]", "Time to wait (seconds) before re-broadcasting a pending transaction with higher gas price (default: 60)")
@@ -40,6 +41,9 @@ program
         }
         if (args.tokens !== undefined) {
             process.env.TOKENS = args.tokens;
+        }
+        if(args.excludeTokens !== undefined) {
+            process.env.EXCLUDE_TOKENS = args.excludeTokens;
         }
         if (args.dbPath !== undefined) {
             process.env.DB_PATH = args.dbPath;

--- a/src/database/repository.js
+++ b/src/database/repository.js
@@ -95,7 +95,6 @@ WHERE out.estimation <= :dt ${inSnipped}
 ORDER BY out.estimation ASC ${inSnippedLimit}`;
 
         if (inSnipped !== "") {
-            console.log("filter tokens: ", tokenFilter)
             return this.app.db.query(sqlquery, {
                 replacements: {
                     dt: checkDate,

--- a/src/database/repository.js
+++ b/src/database/repository.js
@@ -68,11 +68,13 @@ class Repository {
         });
     }
 
-    async getLiquidations(checkDate, onlyTokens, limitRows) {
+    async getLiquidations(checkDate, onlyTokens, excludeTokens, limitRows) {
         let inSnipped = "";
         let inSnippedLimit = "";
-        if (onlyTokens !== undefined) {
-            inSnipped = "and out.superToken in (:tokens)";
+        // if configured onlyTokens we don't filter by excludeTokens
+        const tokenFilter = onlyTokens !== undefined ? onlyTokens : excludeTokens;
+        if (tokenFilter !== undefined) {
+            inSnipped = `and out.superToken ${ onlyTokens !== undefined ? "in" : "not in" } (:tokens)`;
         }
         if (limitRows !== undefined && limitRows > 0 && limitRows < 101) {
             inSnippedLimit = `LIMIT ${limitRows}`;
@@ -93,24 +95,28 @@ WHERE out.estimation <= :dt ${inSnipped}
 ORDER BY out.estimation ASC ${inSnippedLimit}`;
 
         if (inSnipped !== "") {
+            console.log("filter tokens: ", tokenFilter)
             return this.app.db.query(sqlquery, {
                 replacements: {
                     dt: checkDate,
-                    tokens: onlyTokens
+                    tokens: tokenFilter
                 },
                 type: QueryTypes.SELECT
             });
         }
+
         return this.app.db.query(sqlquery, {
             replacements: {dt: checkDate},
             type: QueryTypes.SELECT
         });
     }
 
-    async getNumberOfBatchCalls(checkDate, onlyTokens) {
+    async getNumberOfBatchCalls(checkDate, onlyTokens, excludeTokens) {
         let inSnipped = "";
-        if (onlyTokens !== undefined) {
-            inSnipped = "and out.superToken in (:tokens)";
+        // if configured onlyTokens we don't filter by excludeTokens
+        const tokenFilter = onlyTokens !== undefined ? onlyTokens : excludeTokens;
+        if (tokenFilter !== undefined) {
+            inSnipped = `and out.superToken ${ onlyTokens !== undefined ? "in" : "not in" } (:tokens)`;
         }
 
         const sqlquery = `SELECT superToken, count(*) as numberTxs  FROM (SELECT agr.superToken, agr.sender, agr.receiver,
@@ -132,7 +138,7 @@ order by count(*) desc`;
             return this.app.db.query(sqlquery, {
                 replacements: {
                     dt: checkDate,
-                    tokens: onlyTokens
+                    tokens: tokenFilter
                 },
                 type: QueryTypes.SELECT
             });

--- a/src/httpserver/server.js
+++ b/src/httpserver/server.js
@@ -31,7 +31,9 @@ class HTTPServer {
     this.server.get("/nextliquidations", async (req, res) => {
       const liquidations = await this.app.db.queries.getLiquidations(
         this.app.time.getTimeWithDelay(-3600),
-        this.app.config.TOKENS);
+        this.app.config.TOKENS,
+        this.app.config.EXCLUDED_TOKENS
+      );
       try {
         res.send(liquidations);
       } catch (e) {

--- a/src/web3client/liquidator.js
+++ b/src/web3client/liquidator.js
@@ -23,7 +23,7 @@ class Liquidator {
       let haveBatchWork = [];
       // if we have a batchLiquidator contract, use batch calls
       if (this.app.config.BATCH_CONTRACT !== undefined) {
-        haveBatchWork = await this.app.db.queries.getNumberOfBatchCalls(checkDate, this.app.config.TOKENS);
+        haveBatchWork = await this.app.db.queries.getNumberOfBatchCalls(checkDate, this.app.config.TOKENS, this.app.config.EXCLUDED_TOKENS);
         if(haveBatchWork.length > 0) {
           this.app.logger.debug(JSON.stringify(haveBatchWork));
         }
@@ -31,7 +31,7 @@ class Liquidator {
       if (haveBatchWork.length > 0) {
         await this.multiTermination(haveBatchWork, checkDate);
       } else {
-        const work = await this.app.db.queries.getLiquidations(checkDate, this.app.config.TOKENS, this.app.config.MAX_TX_NUMBER);
+        const work = await this.app.db.queries.getLiquidations(checkDate, this.app.config.TOKENS, this.app.config.EXCLUDED_TOKENS, this.app.config.MAX_TX_NUMBER);
         await this.singleTerminations(work);
       }
     } catch (err) {

--- a/src/web3client/liquidator.js
+++ b/src/web3client/liquidator.js
@@ -113,6 +113,7 @@ class Liquidator {
       const streams = await this.app.db.queries.getLiquidations(
         checkDate,
         batch.superToken,
+        this.app.config.EXCLUDED_TOKENS,
         this.app.config.MAX_TX_NUMBER
       );
 


### PR DESCRIPTION
Add `EXCLUDED_TOKENS` option to sentinel.

This option allows sentinel operator to exclude a set of tokens that don't want to make liquidations.

Rules applied:

- If `TOKENS` option is set `EXCLUDED_TOKENS` is ignore.
- Set/remove `EXCLUDED_TOKENS`  options will not required a resync of sentinel database.

`EXCLUDED_TOKENS` can be set on .env file or by using `-e <address>` as cmd arg