### PR TITLE
Add check to unsupported network

### DIFF
--- a/src/config/configuration.js
+++ b/src/config/configuration.js
@@ -113,6 +113,9 @@ class Config {
 
   loadNetworkInfo (chainId) {
     const network = metadata.filter(x => x.chainId === chainId)[0];
+    if(network === undefined) {
+        throw Error(`Config.loadNetworkInfo(): unknown chainId: ${chainId}`);
+    }
     const contractsV1 = network.contractsV1 || {};
     this.EPOCH_BLOCK = contractsV1.startBlockV1 || 0;
     this.BATCH_CONTRACT = contractsV1.batchLiquidator || undefined;


### PR DESCRIPTION
If Sentinel RPC doesn't match metadata chainId, throw an error and stop sentinel boot.