### PR TITLE
reduce eth_blockNumber calls by 50% (#189)

### DIFF
--- a/src/boot/loadEvents.js
+++ b/src/boot/loadEvents.js
@@ -26,7 +26,7 @@ class LoadEvents {
 
       let pullCounter = blockNumber;
       const currentBlockNumber = await this.app.client.getCurrentBlockNumber(this.app.config.BLOCK_OFFSET);
-      const realBlockNumber = await this.app.client.getCurrentBlockNumber();
+      const realBlockNumber = currentBlockNumber + this.app.config.BLOCK_OFFSET;
       this.app.logger.info(`scanning blocks from ${pullCounter} to ${currentBlockNumber} - real ${realBlockNumber}`);
 
       const queue = async.queue(async function (task) {


### PR DESCRIPTION
Doesn't make sense to call eth_blockNumber twice here, it can be calculated

Done by: @PeterTheOne