### PR TITLE
Reduce eth_getTransactionCount by not doing it every liquidation run

### DIFF
--- a/src/web3client/liquidator.js
+++ b/src/web3client/liquidator.js
@@ -68,6 +68,9 @@ class Liquidator {
   }
 
   async singleTerminations (work) {
+    if (work.length === 0) {
+      return;
+    }
     const wallet = this.app.client.getAccount();
     const chainId = await this.app.client.getChainId();
     const networkAccountNonce = await this.app.client.web3.eth.getTransactionCount(wallet.address);


### PR DESCRIPTION
It seems like there is a eth_getTransactionCount call for almost every block? So just don't do that call if it is not needed.