### PR TITLE
Fix #195 - First gas estimation can go above defined limit

### DIFF
--- a/src/transaction/gas.js
+++ b/src/transaction/gas.js
@@ -25,10 +25,19 @@ class Gas {
 
   async getGasPrice () {
     try {
-      const price = await this.app.client.web3.eth.getGasPrice();
+      const gasPrice = await this.app.client.web3.eth.getGasPrice();
+      let hitGasPriceLimit = false;
+      if (this.app.config.MAX_GAS_PRICE !== undefined &&
+          parseInt(gasPrice) >= this.app.config.MAX_GAS_PRICE
+      ) {
+          this.app.logger.warn(`Hit gas price limit of ${this.app.config.MAX_GAS_PRICE}`);
+          this.app.notifier.sendNotification(`Hit gas price limit of ${this.app.config.MAX_GAS_PRICE}`);
+          hitGasPriceLimit = true;
+      }
       return {
         error: undefined,
-        gasPrice: price
+        gasPrice: gasPrice,
+        hitGasPriceLimit: hitGasPriceLimit
 
       };
     } catch (err) {
@@ -41,19 +50,24 @@ class Gas {
 
   getUpdatedGasPrice (originalGasPrice, retryNumber, step) {
     let gasPrice = originalGasPrice;
+    let hitGasPriceLimit = false;
     if (retryNumber > 1) {
       if (this.app.config.MAX_GAS_PRICE !== undefined &&
         parseInt(originalGasPrice) >= this.app.config.MAX_GAS_PRICE
       ) {
-        this.app.logger.debug(`Hit gas price limit of ${this.app.config.MAX_GAS_PRICE}`);
+        this.app.logger.warn(`Hit gas price limit of ${this.app.config.MAX_GAS_PRICE}`);
         this.app.notifier.sendNotification(`Hit gas price limit of ${this.app.config.MAX_GAS_PRICE}`);
         gasPrice = this.app.config.MAX_GAS_PRICE;
+        hitGasPriceLimit = true;
       } else {
         gasPrice = Math.ceil(parseInt(gasPrice) * step);
       }
       this.app.logger.debug(`update gas price from ${originalGasPrice} to ${gasPrice}`);
     }
-    return gasPrice;
+    return {
+      gasPrice: gasPrice,
+      hitGasPriceLimit: hitGasPriceLimit
+    };
   }
 }
 

--- a/src/transaction/gas.js
+++ b/src/transaction/gas.js
@@ -23,9 +23,9 @@ class Gas {
     }
   }
 
-  async getGasPrice () {
+  async getCappedGasPrice () {
     try {
-      const gasPrice = await this.app.client.web3.eth.getGasPrice();
+      const gasPrice = await this.app.client.web3.eth.getCappedGasPrice();
       let hitGasPriceLimit = false;
       if (this.app.config.MAX_GAS_PRICE !== undefined &&
           parseInt(gasPrice) >= this.app.config.MAX_GAS_PRICE


### PR DESCRIPTION
This PR introduce hitGasPriceLimit to all phases on liquidation job.

This fix is deceptively simple but have multi implications on liquidation jobs.

Before merging this PR needs to follow:
- [x] @d10r Review and discussion (possible simplification)
- [ ] Tests against this specific cases:
    - [x] Gas limit is poorly defined forcing sentinel to stop sending liquidations (_no solution, but we should enter a different mode and notify operator_).
    - [x] Long time window of gas price spike.
    - [x] Any changes should take into consideration EIP 1559.
