### PR TITLE
Add URL parameters for custom timeframe and token to /nextliquidations endpoint

### DIFF
--- a/src/httpserver/server.js
+++ b/src/httpserver/server.js
@@ -27,13 +27,16 @@ class HTTPServer {
         res.status(503).send();
       }
     });
-
     this.server.get("/nextliquidations", async (req, res) => {
+      const timeframe = req.query.timeframe || 3600; // Default timeframe is 3600 seconds (1 hour)
+      const token = req.query.token || null; // Default token is null (all tokens)
+
       const liquidations = await this.app.db.queries.getLiquidations(
-        this.app.time.getTimeWithDelay(-3600),
-        this.app.config.TOKENS,
+        this.app.time.getTimeWithDelay(-timeframe),
+        token ? [token] : this.app.config.TOKENS,
         this.app.config.EXCLUDED_TOKENS
       );
+      
       try {
         res.send(liquidations);
       } catch (e) {


### PR DESCRIPTION
Currently, the endpoint is hardcoded to show projected liquidations for the next hour based on the configured tokens.

- The timeframe parameter allows the caller to specify the desired timeframe for liquidations in seconds. If not provided, it defaults to 3600 seconds (1 hour).

- The token parameter enables the caller to query liquidations for a specific token by providing its address. If not provided, liquidations for all configured tokens will be retrieved.

fixes #90 
