### PR TITLE
Fix #227 - Reduce low balance alerts

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -218,6 +218,7 @@ class App {
             } catch (err) {
                 this.logger.warn(`error loading thresholds.json`);
                 await this.db.queries.updateThresholds({});
+                this.config.SENTINEL_BALANCE_THRESHOLD = 0;
             }
 
 

--- a/src/web3client/client.js
+++ b/src/web3client/client.js
@@ -8,6 +8,7 @@ const SuperfluidGovernance = require("@superfluid-finance/ethereum-contracts/bui
 const BatchContract = require("../abis/BatchLiquidator.json");
 const TogaContract = require("@superfluid-finance/ethereum-contracts/build/contracts/TOGA.json");
 const { wad4human } = require("@decentral.ee/web3-helpers");
+const BN = require("bn.js");
 
 /*
  *   Web3 and superfluid client:
@@ -244,6 +245,14 @@ class Client {
       return this.web3.eth.getBalance(this.agentAccounts.address);
     }
   }
+
+    async isAccountBalanceBelowMinimum () {
+        const balance = await this.getAccountBalance();
+        return {
+          isBelow: new BN(balance).lt(new BN(this.app.config.SENTINEL_BALANCE_THRESHOLD)),
+          balance: balance
+        };
+    }
 
   getAccount () {
     return this.agentAccounts;


### PR DESCRIPTION
This PR close issue #227 by implementing a interval skip mechanic that don't affect the global heath report.

If no threshold file is present, we default `SENTINEL_BALANCE_THRESHOLD` to zero. This implies that no report will be made because sentinel balance can't be less than 0.