### PR TITLE
Aliase name

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -178,7 +178,7 @@ class App {
 
     async start() {
         try {
-            this.logger.debug(`booting sentinel`);
+            this.logger.debug(`booting - ${this.config.INSTANCE_NAME}`);
             this._isShutdown = false;
             // send notification about time sentinel started including timestamp
             this.notifier.sendNotification(`Sentinel started at ${new Date()}`);

--- a/src/config/configuration.js
+++ b/src/config/configuration.js
@@ -65,6 +65,7 @@ class Config {
     this.FASTSYNC = config.fastsync !== "false";
     this.IPFS_GATEWAY = process.env.IPFS_GATEWAY || "https://cloudflare-ipfs.com/ipfs/"
     this.PIRATE = this._parseToBool(config.pirate);
+    this.INSTANCE_NAME = config.INSTANCE_NAME || "Sentinel";
   }
 
   _initializeFromEnvVariables() {
@@ -110,6 +111,7 @@ class Config {
     this.BLOCK_OFFSET = process.env.BLOCK_OFFSET || 12;
     this.MAX_TX_NUMBER = process.env.MAX_TX_NUMBER || 100;
     this.NO_REMOTE_MANIFEST = this._parseToBool(process.env.NO_REMOTE_MANIFEST, false);
+    this.INSTANCE_NAME =  process.env.INSTANCE_NAME || "Sentinel";
   }
 
   _parseToBool(value, defaultValue = false) {
@@ -179,6 +181,7 @@ class Config {
 
   getConfigurationInfo () {
     return {
+      INSTANCE_NAME: this.INSTANCE_NAME,
       HTTP_RPC_NODE: this.HTTP_RPC_NODE,
       FASTSYNC: this.FASTSYNC,
       OBSERVER: this.OBSERVER,

--- a/src/database/businessRepository.js
+++ b/src/database/businessRepository.js
@@ -7,7 +7,6 @@ const SQLRepository = require("./SQLRepository");
 class BusinessRepository {
 
     constructor(app) {
-        console.log("BusinessRepository constructor")
         if(!app) {
             throw new Error("BusinessRepository: app is not defined");
         }
@@ -24,7 +23,6 @@ class BusinessRepository {
     }
 
     static getInstance(app) {
-        console.log("calling getInstance from businessRepository");
         if (!BusinessRepository._instance) {
 
             BusinessRepository._instance = new BusinessRepository(app);

--- a/src/database/systemRepository.js
+++ b/src/database/systemRepository.js
@@ -5,7 +5,6 @@ const SQLRepository = require("./SQLRepository");
 
 class SystemRepository {
     constructor(app) {
-        console.log("SystemRepository constructor")
         if(!app) {
             throw new Error("SystemRepository: app is not defined");
         }
@@ -21,7 +20,6 @@ class SystemRepository {
     }
 
     static getInstance(app) {
-        console.log("calling getInstance from systemRepository");
         if (!SystemRepository._instance) {
             SystemRepository._instance = new SystemRepository(app);
         }

--- a/test/unit-tests/configuration.test.js
+++ b/test/unit-tests/configuration.test.js
@@ -34,7 +34,8 @@ const defaultConfig = {
   FASTSYNC: false,
   IPFS_GATEWAY: "http://localhost:8080/ipfs/",
   PIRATE: false,
-  NO_REMOTE_MANIFEST: false
+  NO_REMOTE_MANIFEST: false,
+  INSTANCE_NAME: "Test-Sentinel",
 };
 
 // set environment variables from the given config object


### PR DESCRIPTION
This PR introduce a configuration that can give a sentinel instance a name.

In .env file now is possible to set `INSTANCE_NAME` variable.