### PR TITLE
Fix notifications

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -145,6 +145,10 @@ HTTP_RPC_NODE=
 ## If you want notifications delivered through other channels, consider creating a notifier implementation for that channel -
 ## see `src/services/slackNotifier.js` for a blueprint. PRs welcome!
 
+## If notifications are enabled, setting this enables alerts when the sentinel account balance goes below the specified threshold.
+## Note that the value is in wei. Thus in order to set a threshold of 1 native token (e.g. ETH), the value should be 1000000000000000000.
+#SENTINEL_BALANCE_THRESHOLD=0
+
 
 ## --- TECHNICAL PARAMETERS ---
 

--- a/src/app.js
+++ b/src/app.js
@@ -195,9 +195,10 @@ class App {
             }
             // create all web3 infrastructure needed
             await this.client.init();
-            const balanceMsg = `RPC connected with chainId ${await this.client.getChainId()}`
-                + this.config.OBSERVER ? "" :
-                `account ${this.client.accountManager.getAccountAddress(0)} has balance ${wad4human(await this.client.accountManager.getAccountBalance(0))}`;
+            const balanceMsg = `RPC connected with chainId ${await this.client.getChainId()}` + (
+                this.config.OBSERVER ? "" :
+                ` - account ${this.client.accountManager.getAccountAddress(0)} has balance ${wad4human(await this.client.accountManager.getAccountBalance(0))}`
+            );
             this.notifier.sendNotification(balanceMsg);
 
             //check conditions to decide if getting snapshot data

--- a/src/config/configuration.js
+++ b/src/config/configuration.js
@@ -115,7 +115,7 @@ class Config {
     this.NO_REMOTE_MANIFEST = this._parseToBool(process.env.NO_REMOTE_MANIFEST, false);
     this.RPC_STUCK_THRESHOLD = process.env.RPC_STUCK_THRESHOLD || (this.POLLING_INTERVAL * 4) / 1000;
     this.INSTANCE_NAME =  process.env.INSTANCE_NAME || "Sentinel";
-    this.SENTINEL_BALANCE_THRESHOLD = process.env.SENTINEL_BALANCE_THRESHOLD || 0;
+    this.SENTINEL_BALANCE_THRESHOLD = process.env.SENTINEL_BALANCE_THRESHOLD || "0";
   }
 
   _parseToBool(value, defaultValue = false) {

--- a/src/web3client/accountManager.js
+++ b/src/web3client/accountManager.js
@@ -86,16 +86,15 @@ class AccountManager {
     }
 
     async isAccountBalanceBelowMinimum(index = 0, threshold) {
+        console.log("isAccountBalanceBelowMinimum index: ", index, " threshold: ", threshold);
         if (!this.accounts[index]) {
             throw new Error("AccountManager: account does not exist");
         }
-        if (!BN.isBN(threshold)) {
-            throw new Error("AccountManager: invalid threshold");
-        }
+        const thresholdBN = new BN(threshold);
 
         const balance = new BN(await this.getAccountBalance(index));
         return {
-            isBelow: balance.lt(threshold),
+            isBelow: balance.lt(thresholdBN),
             balance: balance
         };
     }


### PR DESCRIPTION
There was a type mismatch when checking account balance for notifications and a bug in constructing the initial notification.
Also added the config item `SENTINEL_BALANCE_THRESHOLD` to the example env.